### PR TITLE
Add contextual response chips to chat interface

### DIFF
--- a/src/app/_components/client/chat.tsx
+++ b/src/app/_components/client/chat.tsx
@@ -23,6 +23,7 @@ export default function Chat({
     handleInputChange, handleSubmit,
     stop, reload,
     addToolResult } = useChat({
+      api: '/api/chat-with-chips',
       id,
       initialMessages,
       maxSteps: 5,
@@ -54,7 +55,36 @@ export default function Chat({
               ?.filter(part => part.type !== 'source')
               .map((part, index) => {
                 if (part.type === 'text') {
-                  return <div key={index}>{part.text}</div>;
+                  const text = part.text;
+
+                  // Check if this text contains chips
+                  if (text.includes('CHIPS:')) {
+                    const [mainText, chipsText] = text.split('CHIPS:');
+                    const chips = chipsText?.trim()
+                      .split('|')
+                      .map(chip => chip.trim().replace(/\[|\]/g, ''));
+
+                    return (
+                      <div key={index}>
+                        <div>{mainText?.trim()}</div>
+                        {chips && chips.length > 0 && (
+                          <div className="flex gap-2 mt-2">
+                            {chips.map((chip, chipIndex) => (
+                              <button
+                                key={chipIndex}
+                                className="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm hover:bg-blue-200"
+                                onClick={() => console.log('Clicked chip:', chip)}
+                              >
+                                {chip}
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  }
+
+                  return <div key={index}>{text}</div>;
                 }
 
                 // if AI decided to use a tool:

--- a/src/app/api/chat-with-chips/route.ts
+++ b/src/app/api/chat-with-chips/route.ts
@@ -1,0 +1,59 @@
+import { openai } from '@ai-sdk/openai';
+import {
+    appendResponseMessages,
+    streamText,
+    createIdGenerator,
+    appendClientMessage,
+    type Message
+} from 'ai';
+import { saveChat, loadChat } from 'tools/chat-store';
+import { z } from 'zod';
+import { errorHandler } from '~/lib/utils';
+
+// Allow streaming responses up to 30 seconds
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+
+    const { message, id } = await req.json() as {
+        message: Message,
+        id: string
+    };
+
+    const previousMessages = await loadChat(id);
+
+    const messages = appendClientMessage({
+        messages: previousMessages,
+        message,
+    });
+
+    const result = streamText({
+        model: openai('gpt-4o-mini'),
+        system: `You are a helpful assistant who is knowledgeable about films, shows, animes and all sorts of video work. You like to make recommendations based on what the user previously liked and what the user is in the mood for.
+
+IMPORTANT: At the end of every response, add a line with contextual action chips in this exact format:
+CHIPS: [chip1] | [chip2] | [chip3] | [chip4]
+
+The chips should be VERY SPECIFIC to what you just recommended or discussed. Examples:
+- If you recommend "The Wire": [Add The Wire to watchlist] | [Tell me more about The Wire] | [I've seen The Wire] | [Show similar crime dramas]
+- If you mention multiple shows: [Tell me more about True Detective] | [Add Brooklyn Nine-Nine to watchlist] | [I prefer serious over comedy] | [Show more HBO shows]
+
+Make the chips actionable and specific to the exact content you mentioned.`,
+        messages,
+        async onFinish({ response }) {
+            await saveChat({
+                id,
+                messages: appendResponseMessages({
+                    messages,
+                    responseMessages: response.messages,
+                }),
+            });
+        },
+    });
+
+    void result.consumeStream();
+
+    return result.toDataStreamResponse({
+        getErrorMessage: errorHandler,
+    });
+}

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,9 +1,11 @@
 import { openai } from '@ai-sdk/openai';
-import { appendResponseMessages, 
-  streamText, 
-  createIdGenerator, 
-  appendClientMessage, 
-  type Message } from 'ai';
+import {
+  appendResponseMessages,
+  streamText,
+  createIdGenerator,
+  appendClientMessage,
+  type Message
+} from 'ai';
 import { saveChat, loadChat } from 'tools/chat-store';
 import { z } from 'zod';
 import { errorHandler } from '~/lib/utils';
@@ -19,7 +21,7 @@ export async function POST(req: Request) {
   };
 
   const previousMessages = await loadChat(id);
-  
+
   const messages = appendClientMessage({
     messages: previousMessages,
     message,
@@ -34,32 +36,7 @@ export async function POST(req: Request) {
       prefix: 'msgs',
       size: 16,
     }),
-    tools: {
-      // server-side tool with execute function:
-      getWeatherInformation: {
-        description: 'show the weather in a given city to the user',
-        parameters: z.object({ city: z.string() }),
-        execute: async ({}: { city: string }) => {
-          const weatherOptions = ['sunny', 'cloudy', 'rainy', 'snowy', 'windy'];
-          return weatherOptions[
-            Math.floor(Math.random() * weatherOptions.length)
-          ];
-        },
-      },
-      // client-side tool that starts user interaction:
-      askForConfirmation: {
-        description: 'Ask the user for confirmation.',
-        parameters: z.object({
-          message: z.string().describe('The message to ask for confirmation.'),
-        }),
-      },
-      // client-side tool that is automatically executed on the client:
-      getLocation: {
-        description:
-          'Get the user location. Always ask for confirmation before using this tool.',
-        parameters: z.object({}),
-      },
-    },
+    tools: {},
     async onFinish({ response }) {
       await saveChat({
         id,
@@ -71,11 +48,11 @@ export async function POST(req: Request) {
     },
   });
 
-    // consume the stream to ensure it runs to completion & triggers onFinish
+  // consume the stream to ensure it runs to completion & triggers onFinish
   // even when the client response is aborted:
   void result.consumeStream(); // no await
 
-return result.toDataStreamResponse({
-  getErrorMessage: errorHandler,
-})
+  return result.toDataStreamResponse({
+    getErrorMessage: errorHandler,
+  })
 }


### PR DESCRIPTION
## Changes
- Create new `/api/chat-with-chips` endpoint with enhanced system prompt
- Add chip parsing logic to Chat.tsx to extract and display action buttons
- Parse LLM responses in format: "response text CHIPS: [chip1] | [chip2] | [chip3] | [chip4]"
- Display chips as clickable buttons below each AI response