### PR TITLE
feat: migrate to PostgreSQL schema with movie data persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,11 @@ Chat history:
 
 UI:
 - add new chat button on chat page
-- better sign up form on homepage
+- better sign up form on homepage (should have google sign up)
 - homepage when sign up show cards for each page: Watchlist, Watch history, taste profile
+- remove Watchlist, Watch history, taste profile from sidebar
+- make sidebar more obvious and by default not shown
+- add a randomly generated welcome message from the Genie for each new chat?
 
 Data persistence:
 - switch from local storage to Supabase

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,5 +1,4 @@
 import { type Config } from "drizzle-kit";
-
 import { env } from "~/env";
 
 export default {
@@ -8,5 +7,4 @@ export default {
   dbCredentials: {
     url: env.DATABASE_URL,
   },
-  tablesFilter: ["week2-chatbot_*"],
 } satisfies Config;

--- a/scripts/reset-db.ts
+++ b/scripts/reset-db.ts
@@ -1,0 +1,41 @@
+// scripts/reset-db.ts
+import { sql } from "drizzle-orm";
+import { db } from "~/server/db";
+
+async function resetDatabase() {
+    console.log("🗑️  Dropping all tables...");
+
+    // Drop all tables in the correct order (respecting foreign keys)
+    await db.execute(sql`DROP TABLE IF EXISTS messages CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS chats CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS movie_interactions CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS user_movies CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS user_preferences CASCADE`);
+
+    // Drop the old prefixed tables
+    await db.execute(sql`DROP TABLE IF EXISTS "week2-chatbot_messages" CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS "week2-chatbot_chat" CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS "week2-chatbot_account" CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS "week2-chatbot_session" CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS "week2-chatbot_user" CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS "week2-chatbot_verification" CASCADE`);
+
+    // Drop better-auth tables too
+    await db.execute(sql`DROP TABLE IF EXISTS account CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS session CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS "user" CASCADE`);
+    await db.execute(sql`DROP TABLE IF EXISTS verification CASCADE`);
+
+    // Drop enums
+    await db.execute(sql`DROP TYPE IF EXISTS interaction_type CASCADE`);
+    await db.execute(sql`DROP TYPE IF EXISTS collection_type CASCADE`);
+    await db.execute(sql`DROP TYPE IF EXISTS media_type CASCADE`);
+
+    // Clear Drizzle's migration table
+    await db.execute(sql`DROP TABLE IF EXISTS __drizzle_migrations CASCADE`);
+    await db.execute(sql`DROP SCHEMA IF EXISTS drizzle CASCADE`);
+
+    console.log("✅ All tables dropped!");
+}
+
+resetDatabase().catch(console.error);

--- a/src/app/_components/client/MovieCardsSection.tsx
+++ b/src/app/_components/client/MovieCardsSection.tsx
@@ -4,15 +4,7 @@ import { useState, useEffect } from 'react'
 import { MovieCard } from './MovieCard'
 import { MovieDetailsModal } from './MovieDetailsModal'
 
-export interface MovieData {
-    id: number
-    title: string
-    poster_url: string | null
-    release_date?: string
-    rating?: number
-    overview?: string
-    media_type: 'movie' | 'tv'
-}
+import { type MovieData } from "~/app/types/index"
 
 interface MovieCardsSectionProps {
     movies: MovieData[]

--- a/src/app/_components/client/chat.tsx
+++ b/src/app/_components/client/chat.tsx
@@ -15,6 +15,7 @@ import { WelcomeMessage } from './WelcomeMessage';
 
 import { useRouter } from 'next/navigation'
 import { api } from "~/trpc/react"
+import { log } from 'console';
 
 function Spinner() {
   return (
@@ -75,6 +76,7 @@ export default function Chat({
           }));
 
           try {
+
             const response = await fetch('/api/generate-chips', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
@@ -93,6 +95,7 @@ export default function Chat({
 
             const data = await response.json() as { chips: Chip[] };
             setConversationChips(data.chips);
+
           } catch (error) {
             console.error('Failed to generate chips:', error);
             setConversationChips([]);

--- a/src/app/api/chat-tmdb-tool/route.ts
+++ b/src/app/api/chat-tmdb-tool/route.ts
@@ -10,6 +10,7 @@ import { saveChat, loadChat } from 'tools/chat-store';
 import { z } from 'zod';
 import { errorHandler } from '~/lib/utils';
 import { api } from "~/trpc/server"
+import { generateChatTitle } from 'tools/message-utils';
 
 interface TMDBSearchResult {
   id: number;
@@ -26,26 +27,6 @@ interface TMDBSearchResult {
 
 interface TMDBSearchResponse {
   results?: TMDBSearchResult[];
-}
-
-function generateChatTitle(message: string): string {
-  // Remove extra whitespace and trim
-  const cleaned = message.trim().replace(/\s+/g, ' ');
-
-  // Take first 40 chars, try to break at word boundary
-  if (cleaned.length <= 40) {
-    return cleaned;
-  }
-
-  const truncated = cleaned.substring(0, 40);
-  const lastSpace = truncated.lastIndexOf(' ');
-
-  // If we found a space in the last 10 chars, break there
-  if (lastSpace > 30) {
-    return truncated.substring(0, lastSpace) + '...';
-  }
-
-  return truncated + '...';
 }
 
 // Allow streaming responses up to 30 seconds

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -4,3 +4,52 @@ export interface Chip {
     'tone_shift' | 'philosophical' | 'nostalgic' | 'style' | 'meta' |
     'similar_but_different' | 'hidden_gem' | 'completion'
 }
+
+
+export interface MovieData {
+    id: number;
+    title: string;
+    poster_url: string | null;
+    media_type: 'movie' | 'tv';
+    release_date?: string;
+    rating?: number;
+    overview?: string;
+}
+
+// Additional types for database operations
+export type CollectionType = 'watchlist' | 'history';
+export type InteractionType = 'like' | 'dislike' | 'watchlist' | 'watched';
+
+// Type for the full movie object stored in user_movies table
+export interface UserMovie extends MovieData {
+    userId: string;
+    collectionType: CollectionType;
+    addedAt: Date;
+}
+
+// Type guard for MovieData
+export function isMovieData(data: unknown): data is MovieData {
+    // First, check if it's an object
+    if (typeof data !== 'object' || data === null) {
+        return false;
+    }
+
+    // Now TypeScript knows it's an object, so we can use 'in' operator
+    if (!('id' in data) || !('title' in data) || !('media_type' in data)) {
+        return false;
+    }
+
+    // Cast to a temporary type for property checks
+    const obj = data as { id: unknown; title: unknown; media_type: unknown };
+
+    return (
+        typeof obj.id === 'number' &&
+        typeof obj.title === 'string' &&
+        (obj.media_type === 'movie' || obj.media_type === 'tv')
+    );
+}
+
+// Type guard for MovieData array
+export function isMovieDataArray(data: unknown): data is MovieData[] {
+    return Array.isArray(data) && data.every(isMovieData);
+}

--- a/tools/message-utils.ts
+++ b/tools/message-utils.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+import type { Message } from 'ai';
+import type { MovieData } from '~/app/types/index';
+
+/**
+ * Extracts movie data from various message part formats
+ * Handles both 'tool-result' and 'tool-invocation' formats from Vercel AI SDK
+ * 
+ * Note: We use 'any' here because the AI SDK uses different types for streaming vs saved messages
+ */
+export function extractToolResults(message: Message): MovieData[] | null {
+    if (message.role !== 'assistant' || !('parts' in message) || !message.parts) {
+        return null;
+    }
+
+    const toolResults: MovieData[] = [];
+    const parts = message.parts as any[];
+
+    for (const part of parts) {
+        if (!part || typeof part !== 'object') continue;
+
+        // Format 1: tool-result (from saved messages)
+        if (part.type === 'tool-result' && part.toolName === 'media_lookup' && part.result && !part.result.error) {
+            toolResults.push(part.result as MovieData);
+        }
+        // Format 2: tool-invocation (from streaming responses)
+        else if (part.type === 'tool-invocation' && part.toolInvocation) {
+            const invocation = part.toolInvocation;
+            if (invocation.toolName === 'media_lookup' &&
+                invocation.state === 'result' &&
+                invocation.result &&
+                !invocation.result.error) {
+                toolResults.push(invocation.result as MovieData);
+            }
+        }
+    }
+
+    return toolResults.length > 0 ? toolResults : null;
+}
+
+/**
+ * Reconstructs message parts array from saved tool results
+ */
+export function reconstructMessageParts(content: string, toolResults: MovieData[]): any[] {
+    return [
+        { type: 'text', text: content },
+        ...toolResults.map(movie => ({
+            type: 'tool-invocation',
+            toolInvocation: {
+                toolName: 'media_lookup',
+                state: 'result',
+                result: movie
+            }
+        }))
+    ];
+}
+
+/**
+ * Generates a concise chat title from the first message
+ */
+export function generateChatTitle(message: string): string {
+    const cleaned = message.trim().replace(/\s+/g, ' ');
+
+    if (cleaned.length <= 40) {
+        return cleaned;
+    }
+
+    const truncated = cleaned.substring(0, 40);
+    const lastSpace = truncated.lastIndexOf(' ');
+
+    if (lastSpace > 30) {
+        return truncated.substring(0, lastSpace) + '...';
+    }
+
+    return truncated + '...';
+}


### PR DESCRIPTION
- Remove table prefix and create clean database schema
- Add new tables: user_preferences, user_movies, movie_interactions
- Add tool_results JSONB column to messages table for movie data
- Implement enums for type safety (media_type, collection_type, interaction_type)
- Extract and save AI tool invocation results to preserve movie posters
- Refactor message utilities into separate module
- Fix chat/messages foreign key relationships
- Update all queries to use new schema structure

Fixes poster disappearance on refresh by persisting complete message data